### PR TITLE
fix: prevent LastEvent data races

### DIFF
--- a/src/main/java/com.elertan/BUEventService.java
+++ b/src/main/java/com.elertan/BUEventService.java
@@ -4,6 +4,8 @@ import com.elertan.data.LastEventDataProvider;
 import com.elertan.event.BUEvent;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.time.OffsetDateTime;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Consumer;
@@ -12,6 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Singleton
 public class BUEventService implements BUPluginLifecycle {
+
+    private static final int STALE_EVENT_THRESHOLD_SECONDS = 30;
 
     private final ConcurrentLinkedQueue<Consumer<BUEvent>> eventListeners = new ConcurrentLinkedQueue<>();
     private final Consumer<BUEvent> lastEventListener = this::lastEventListener;
@@ -22,6 +26,14 @@ public class BUEventService implements BUPluginLifecycle {
     @Override
     public void startUp() throws Exception {
         lastEventDataProvider.addEventListener(lastEventListener);
+
+        lastEventDataProvider.waitUntilReady(null).whenComplete((__, throwable) -> {
+            if (throwable != null) {
+                log.error("LastEventDataProvider waitUntilReady failed", throwable);
+                return;
+            }
+            cleanupStaleEvents();
+        });
     }
 
     @Override
@@ -37,8 +49,8 @@ public class BUEventService implements BUPluginLifecycle {
         eventListeners.remove(eventListener);
     }
 
-    public CompletableFuture<Void> publishEvent(BUEvent event) {
-        return lastEventDataProvider.update(event);
+    public CompletableFuture<String> publishEvent(BUEvent event) {
+        return lastEventDataProvider.add(event);
     }
 
     private void lastEventListener(BUEvent event) {
@@ -49,5 +61,24 @@ public class BUEventService implements BUPluginLifecycle {
                 log.error("error in listener for last event listener", e);
             }
         }
+    }
+
+    private void cleanupStaleEvents() {
+        lastEventDataProvider.readAll().thenAccept(entries -> {
+            OffsetDateTime threshold = OffsetDateTime.now().minusSeconds(STALE_EVENT_THRESHOLD_SECONDS);
+            for (Map.Entry<String, BUEvent> entry : entries.entrySet()) {
+                BUEvent event = entry.getValue();
+                if (event.getTimestamp() == null || event.getTimestamp().getValue().isBefore(threshold)) {
+                    lastEventDataProvider.remove(entry.getKey())
+                        .exceptionally(ex -> {
+                            log.error("Failed to cleanup stale event", ex);
+                            return null;
+                        });
+                }
+            }
+        }).exceptionally(ex -> {
+            log.error("Failed to read events for cleanup", ex);
+            return null;
+        });
     }
 }

--- a/src/main/java/com.elertan/remote/ObjectListStoragePort.java
+++ b/src/main/java/com.elertan/remote/ObjectListStoragePort.java
@@ -1,0 +1,26 @@
+package com.elertan.remote;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+public interface ObjectListStoragePort<V> extends AutoCloseable {
+
+    CompletableFuture<Map<String, V>> readAll();
+
+    CompletableFuture<String> add(V value);
+
+    CompletableFuture<Void> remove(String entryKey);
+
+    void addListener(Listener<V> listener);
+
+    void removeListener(Listener<V> listener);
+
+    interface Listener<V> {
+
+        void onFullUpdate(Map<String, V> map);
+
+        void onAdd(String entryKey, V value);
+
+        void onRemove(String entryKey);
+    }
+}

--- a/src/main/java/com.elertan/remote/RemoteStorageService.java
+++ b/src/main/java/com.elertan/remote/RemoteStorageService.java
@@ -14,7 +14,7 @@ import com.elertan.remote.firebase.FirebaseRealtimeDatabaseURL;
 import com.elertan.remote.firebase.FirebaseSSEStream;
 import com.elertan.remote.firebase.storageAdapters.GameRulesFirebaseObjectStorageAdapter;
 import com.elertan.remote.firebase.storageAdapters.GroundItemOwnedByKeyListStorageAdapter;
-import com.elertan.remote.firebase.storageAdapters.LastEventFirebaseObjectStorageAdapter;
+import com.elertan.remote.firebase.storageAdapters.LastEventFirebaseObjectListStorageAdapter;
 import com.elertan.remote.firebase.storageAdapters.MembersFirebaseKeyValueStorageAdapter;
 import com.elertan.remote.firebase.storageAdapters.UnlockedItemsFirebaseKeyValueStorageAdapter;
 import com.elertan.utils.StateListenerManager;
@@ -51,7 +51,7 @@ public class RemoteStorageService implements BUPluginLifecycle {
     @Getter
     private ObjectStoragePort<GameRules> gameRulesStoragePort;
     @Getter
-    private ObjectStoragePort<BUEvent> lastEventStoragePort;
+    private ObjectListStoragePort<BUEvent> lastEventStoragePort;
     @Getter
     private KeyListStoragePort<GroundItemOwnedByKey, GroundItemOwnedByData> groundItemOwnedByStoragePort;
     private final Consumer<AccountConfiguration> currentAccountConfigurationChangeListener = this::currentAccountConfigurationChangeListener;
@@ -151,7 +151,7 @@ public class RemoteStorageService implements BUPluginLifecycle {
             firebaseRealtimeDatabase,
             gson
         );
-        lastEventStoragePort = new LastEventFirebaseObjectStorageAdapter(
+        lastEventStoragePort = new LastEventFirebaseObjectListStorageAdapter(
             firebaseRealtimeDatabase,
             gson
         );

--- a/src/main/java/com.elertan/remote/firebase/FirebaseObjectListStorageAdapterBase.java
+++ b/src/main/java/com.elertan/remote/firebase/FirebaseObjectListStorageAdapterBase.java
@@ -1,0 +1,219 @@
+package com.elertan.remote.firebase;
+
+import com.elertan.remote.ObjectListStoragePort;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FirebaseObjectListStorageAdapterBase<V> implements ObjectListStoragePort<V> {
+
+    private final String basePath;
+    private final FirebaseRealtimeDatabase db;
+    private final Function<V, JsonElement> serializer;
+    private final Function<JsonElement, V> deserializer;
+    private final ConcurrentLinkedQueue<Listener<V>> listeners = new ConcurrentLinkedQueue<>();
+
+    private final ConcurrentHashMap<String, V> localCache = new ConcurrentHashMap<>();
+
+    private final Consumer<FirebaseSSE> sseListener = this::sseListener;
+
+    public FirebaseObjectListStorageAdapterBase(
+        String basePath,
+        FirebaseRealtimeDatabase db,
+        Function<V, JsonElement> serializer,
+        Function<JsonElement, V> deserializer
+    ) {
+        FirebaseRealtimeDatabase.validateBasePath(basePath);
+        this.basePath = basePath;
+        this.db = db;
+        this.serializer = serializer;
+        this.deserializer = deserializer;
+
+        FirebaseSSEStream stream = db.getStream();
+        stream.addServerSentEventListener(sseListener);
+    }
+
+    @Override
+    public void close() throws Exception {
+        listeners.clear();
+        localCache.clear();
+
+        FirebaseSSEStream stream = db.getStream();
+        stream.removeServerSentEventListener(sseListener);
+    }
+
+    @Override
+    public CompletableFuture<Map<String, V>> readAll() {
+        return db.get(basePath)
+            .thenApply(jsonElement -> {
+                if (jsonElement == null || jsonElement.isJsonNull()) {
+                    return Collections.emptyMap();
+                }
+
+                JsonObject obj = jsonElement.getAsJsonObject();
+                Map<String, V> map = new HashMap<>();
+
+                for (Map.Entry<String, JsonElement> entry : obj.entrySet()) {
+                    V value = deserializer.apply(entry.getValue());
+                    if (value != null) {
+                        map.put(entry.getKey(), value);
+                    }
+                }
+
+                return map;
+            });
+    }
+
+    @Override
+    public CompletableFuture<String> add(V value) {
+        JsonElement jsonElement = serializer.apply(value);
+        return db.post(basePath, jsonElement)
+            .thenApply(response -> {
+                if (response != null && response.isJsonObject()) {
+                    JsonObject obj = response.getAsJsonObject();
+                    if (obj.has("name")) {
+                        return obj.get("name").getAsString();
+                    }
+                }
+                return null;
+            });
+    }
+
+    @Override
+    public CompletableFuture<Void> remove(String entryKey) {
+        String path = basePath + "/" + entryKey;
+        return db.delete(path);
+    }
+
+    @Override
+    public void addListener(Listener<V> listener) {
+        listeners.add(listener);
+    }
+
+    @Override
+    public void removeListener(Listener<V> listener) {
+        listeners.remove(listener);
+    }
+
+    public ConcurrentHashMap<String, V> getLocalCache() {
+        return localCache;
+    }
+
+    private void sseListener(FirebaseSSE event) {
+        FirebaseSSEType type = event.getType();
+        if (type != FirebaseSSEType.Put) {
+            return;
+        }
+
+        String path = event.getPath();
+        if (!path.startsWith(basePath)) {
+            return;
+        }
+        String[] pathParts = Arrays.stream(path.split("/"))
+            .filter(part -> !part.isEmpty())
+            .toArray(String[]::new);
+        int pathPartsLength = pathParts.length;
+
+        if (pathPartsLength == 1) {
+            // Full update of entire collection
+            handleFullUpdate(event.getData());
+        } else if (pathPartsLength == 2) {
+            // Single entry add/remove
+            String entryKey = pathParts[1];
+            handleEntryUpdate(entryKey, event.getData());
+        } else {
+            log.info(
+                "FirebaseObjectListStorageAdapterBase ({}): too many path parts, ignoring: {}",
+                basePath,
+                path
+            );
+        }
+    }
+
+    private void handleFullUpdate(JsonElement jsonElement) {
+        localCache.clear();
+        Map<String, V> fullMap = new HashMap<>();
+
+        if (jsonElement != null && !jsonElement.isJsonNull() && jsonElement.isJsonObject()) {
+            JsonObject obj = jsonElement.getAsJsonObject();
+            for (Map.Entry<String, JsonElement> entry : obj.entrySet()) {
+                String entryKey = entry.getKey();
+                V value;
+                try {
+                    value = deserializer.apply(entry.getValue());
+                } catch (Exception e) {
+                    log.error("Failed to deserialize value for entry {}", entryKey, e);
+                    continue;
+                }
+                if (value != null) {
+                    localCache.put(entryKey, value);
+                    fullMap.put(entryKey, value);
+                }
+            }
+        }
+
+        notifyListenersOnFullUpdate(fullMap);
+    }
+
+    private void handleEntryUpdate(String entryKey, JsonElement jsonElement) {
+        if (jsonElement == null || jsonElement.isJsonNull()) {
+            // Entry removed
+            localCache.remove(entryKey);
+            notifyListenersOnRemove(entryKey);
+        } else {
+            // Entry added/updated
+            V value;
+            try {
+                value = deserializer.apply(jsonElement);
+            } catch (Exception e) {
+                log.error("Failed to deserialize value for entry {}", entryKey, e);
+                return;
+            }
+
+            if (value != null) {
+                localCache.put(entryKey, value);
+                notifyListenersOnAdd(entryKey, value);
+            }
+        }
+    }
+
+    private void notifyListenersOnFullUpdate(Map<String, V> map) {
+        for (Listener<V> listener : listeners) {
+            try {
+                listener.onFullUpdate(map);
+            } catch (Exception e) {
+                log.error("Failed to notify listener on full update", e);
+            }
+        }
+    }
+
+    private void notifyListenersOnAdd(String entryKey, V value) {
+        for (Listener<V> listener : listeners) {
+            try {
+                listener.onAdd(entryKey, value);
+            } catch (Exception e) {
+                log.error("Failed to notify listener on add", e);
+            }
+        }
+    }
+
+    private void notifyListenersOnRemove(String entryKey) {
+        for (Listener<V> listener : listeners) {
+            try {
+                listener.onRemove(entryKey);
+            } catch (Exception e) {
+                log.error("Failed to notify listener on remove", e);
+            }
+        }
+    }
+}

--- a/src/main/java/com.elertan/remote/firebase/storageAdapters/LastEventFirebaseObjectListStorageAdapter.java
+++ b/src/main/java/com.elertan/remote/firebase/storageAdapters/LastEventFirebaseObjectListStorageAdapter.java
@@ -2,17 +2,16 @@ package com.elertan.remote.firebase.storageAdapters;
 
 import com.elertan.event.BUEvent;
 import com.elertan.event.BUEventGson;
-import com.elertan.remote.firebase.FirebaseObjectStorageAdapterBase;
+import com.elertan.remote.firebase.FirebaseObjectListStorageAdapterBase;
 import com.elertan.remote.firebase.FirebaseRealtimeDatabase;
 import com.google.gson.Gson;
 
-
-public class LastEventFirebaseObjectStorageAdapter extends
-    FirebaseObjectStorageAdapterBase<BUEvent> {
+public class LastEventFirebaseObjectListStorageAdapter extends
+    FirebaseObjectListStorageAdapterBase<BUEvent> {
 
     private final static String PATH = "/LastEvent";
 
-    public LastEventFirebaseObjectStorageAdapter(FirebaseRealtimeDatabase db, Gson gson) {
+    public LastEventFirebaseObjectListStorageAdapter(FirebaseRealtimeDatabase db, Gson gson) {
         super(
             PATH,
             db,


### PR DESCRIPTION
## Summary
- Use Firebase POST to create unique entries per event instead of PUT (prevents overwrites when multiple events fire rapidly)
- Writer cleans up own entry after 10s delay (enough time for SSE propagation)
- Startup cleanup removes stale events (>30s) as fallback

## Changes
- Add `ObjectListStoragePort` interface for keyless list storage
- Add `FirebaseObjectListStorageAdapterBase` using POST for random IDs
- Update `LastEventDataProvider` to use new port type
- Add scheduled cleanup in `BUEventService`

## Test plan
- [x] Trigger multiple rapid events (e.g., level ups) and verify all are received
- [x] Verify events are cleaned up after ~10s
- [x] Restart plugin and verify stale events are cleaned