### PR TITLE
fix: add ownership check to prevent unlocking other players' drops

### DIFF
--- a/src/main/java/com.elertan/ItemUnlockService.java
+++ b/src/main/java/com.elertan/ItemUnlockService.java
@@ -332,6 +332,13 @@ public class ItemUnlockService implements BUPluginLifecycle {
         TileItem tileItem = event.getItem();
         Tile tile = event.getTile();
 
+        // Only unlock items that belong to us (our drops when inventory is full)
+        // Ignore items dropped by other players
+        int ownership = tileItem.getOwnership();
+        if (ownership != TileItem.OWNERSHIP_SELF && ownership != TileItem.OWNERSHIP_GROUP) {
+            return;
+        }
+
         Player localPlayer = client.getLocalPlayer();
         if (localPlayer == null) {
             return;


### PR DESCRIPTION
## Summary
- Add ownership check in `onItemSpawned` to prevent items dropped by other players from being unlocked
- Only items with `OWNERSHIP_SELF` or `OWNERSHIP_GROUP` now trigger unlocks

## Test plan
- [ ] Drop an item with full inventory and verify it gets unlocked
- [ ] Have another player drop an item nearby and verify picking it up does NOT unlock it