### PR TITLE
Remove redundant repaint causing client thread hogging

### DIFF
--- a/src/main/java/com.elertan/panel/screens/main/unlockedItems/items/MainView.java
+++ b/src/main/java/com.elertan/panel/screens/main/unlockedItems/items/MainView.java
@@ -147,9 +147,6 @@ public class MainView extends JPanel implements AutoCloseable {
             AsyncBufferedImage icon = listItem.getIcon();
             icon.addTo(label);
 
-            // repaint when image loads
-            icon.onLoaded(jl::repaint);
-
             UnlockedItem item = listItem.getItem();
             // rich tooltip
             String name = item.getName();


### PR DESCRIPTION
As discussed in Discord, this caused redundant repaints to hog the client thread and cause stutter that gets worse when more icons are visible at once, such as on vertical screens.