### PR TITLE
feat: disable policies on unsupported world types (Deadman, Seasonal, etc.)

### DIFF
--- a/planspec/designs/world-type-policy-support.md
+++ b/planspec/designs/world-type-policy-support.md
@@ -1,0 +1,161 @@
+---
+date: 2026-01-31
+status: approved
+impl-spec: planspec:impl-spec
+---
+
+# World Type Policy Support
+
+> **Next step:** `planspec:impl-spec planspec/designs/world-type-policy-support.md`
+
+## Problem
+
+Policies incorrectly enforce restrictions on special world types like Deadman Mode, where bronzeman rules shouldn't apply. Item unlocks are correctly blocked via `ItemUnlockService.supportedWorldTypes`, but policies in `PolicyBase` have no world type awareness - they only check game rules and account config.
+
+This causes issues like blocking ground item pickup on Deadman worlds, even though Deadman has completely different game rules.
+
+## Success Criteria
+
+**Must have:**
+- Policies do not apply on unsupported world types (DEADMAN, SEASONAL, BETA, NOSAVE_MODE, PVP_ARENA, QUEST_SPEEDRUNNING)
+- BOUNTY added to supported world types (main game with minigame access)
+- Switch from `WorldService` (HTTP API) to `client.getWorldType()` (client API)
+- Single source of truth for supported world types via new `WorldTypeService`
+
+**Quality attributes:**
+- All calls are on client thread - no threading concerns
+- Simpler code - no null checks for `WorldResult`
+
+**Not building:**
+- Per-policy world type overrides
+- User notification when policies are disabled on unsupported worlds
+
+## Approach
+
+Create dedicated `WorldTypeService` for world type checks, inject into `PolicyBase` and `ItemUnlockService`.
+
+### Alternatives Considered
+
+| Alternative | Why Not |
+|-------------|---------|
+| Shared utility in PolicyBase | Couples ItemUnlockService to PolicyBase |
+| Constants class + utility in each consumer | Duplicated logic, easy to diverge |
+
+## Design
+
+### Architecture Overview
+
+```
+WorldTypeService (new)
+├── SUPPORTED_WORLD_TYPES constant
+├── Client injection
+└── isCurrentWorldSupported() → boolean
+
+PolicyBase
+├── Inject WorldTypeService
+└── createContext() checks worldTypeService.isCurrentWorldSupported()
+    → returns "don't apply" context if false
+
+ItemUnlockService
+├── Inject WorldTypeService
+├── Remove supportedWorldTypes constant
+├── Remove WorldService dependency
+└── Replace isCurrentWorldSupportedForUnlockingItems()
+    → call worldTypeService.isCurrentWorldSupported()
+```
+
+**Lifecycle:** `WorldTypeService` is stateless (reads from client), `startUp()`/`shutDown()` are empty. No registration needed in `BUPlugin` lifecycle list.
+
+**Integration points:**
+- `PolicyBase.createContext()` - early return if unsupported world
+- `ItemUnlockService.unlockItem()` and `checkAndNotifyNonSupportedWorldType()` - use new service
+
+### Data Model
+
+Supported world types constant using `net.runelite.api.WorldType`:
+
+```java
+private static final Set<WorldType> SUPPORTED_WORLD_TYPES = Set.of(
+    WorldType.MEMBERS,
+    WorldType.PVP,
+    WorldType.BOUNTY,
+    WorldType.SKILL_TOTAL,
+    WorldType.HIGH_RISK,
+    WorldType.FRESH_START_WORLD,
+    WorldType.LAST_MAN_STANDING
+);
+```
+
+### Interfaces
+
+```java
+@Singleton
+public class WorldTypeService implements BUPluginLifecycle {
+
+    /**
+     * Checks if the current world type is supported for bronzeman features.
+     * Must be called from client thread.
+     *
+     * @return true if policies and unlocks should apply, false otherwise
+     */
+    public boolean isCurrentWorldSupported();
+}
+```
+
+### Behavior
+
+**WorldTypeService.isCurrentWorldSupported():**
+```java
+public boolean isCurrentWorldSupported() {
+    EnumSet<WorldType> worldTypes = client.getWorldType();
+    return worldTypes.stream().allMatch(SUPPORTED_WORLD_TYPES::contains);
+}
+```
+- Returns `true` if all world types are in `SUPPORTED_WORLD_TYPES`
+- Returns `false` if any world type is unsupported (e.g., `DEADMAN`)
+- Empty set returns `true` (vacuous truth via `allMatch`)
+
+**PolicyBase.createContext():**
+- Early check: if `!worldTypeService.isCurrentWorldSupported()` → return context that causes `shouldApplyForRules()` to return `false`
+- Existing logic unchanged otherwise
+
+**ItemUnlockService:**
+- `unlockItem()`: replace `isCurrentWorldSupportedForUnlockingItems()` with `worldTypeService.isCurrentWorldSupported()`
+- `checkAndNotifyNonSupportedWorldType()`: same replacement
+- Remove `WorldService` injection and `supportedWorldTypes` constant
+
+### Testing Requirements
+
+**Critical paths:**
+- Policy does not block actions on Deadman/Seasonal worlds
+- Policy still blocks actions on normal worlds (MEMBERS, PVP, etc.)
+- Item unlocks still work on supported worlds
+- Item unlocks still blocked on unsupported worlds
+
+**Edge cases:**
+- World with multiple types (e.g., `MEMBERS` + `DEADMAN`) → unsupported
+- World with only supported types → supported
+
+**Integration points:**
+- `GroundItemsPolicy` - verify ground item pickup allowed on Deadman
+- `TradePolicy` - verify trading allowed on Deadman
+- `ItemUnlockService` - verify unlocks blocked on Deadman
+
+**Manual testing:**
+- Log into Deadman world, verify policies don't fire
+- Log into normal world, verify policies still work
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| New RuneLite WorldType added | Low | Supported by default (in SUPPORTED set logic) | Monitor RuneLite updates |
+
+## Dependencies
+
+- **Blocking:** None
+- **Non-blocking:** None
+
+## Open Questions
+
+None.

--- a/planspec/implementations/world-type-policy-support.md
+++ b/planspec/implementations/world-type-policy-support.md
@@ -1,7 +1,7 @@
 ---
 date: 2026-01-31
 design-spec: ../designs/world-type-policy-support.md
-status: ready
+status: completed
 executor: planspec:impl-spec-executor
 ---
 

--- a/planspec/implementations/world-type-policy-support.md
+++ b/planspec/implementations/world-type-policy-support.md
@@ -1,0 +1,171 @@
+---
+date: 2026-01-31
+design-spec: ../designs/world-type-policy-support.md
+status: ready
+executor: planspec:impl-spec-executor
+---
+
+# Implementation: World Type Policy Support
+
+> **Execute with:** `planspec:impl-spec-executor planspec/implementations/world-type-policy-support.md`
+
+## Overview
+
+Create `WorldTypeService` to centralize world type checking, integrate into `PolicyBase` and `ItemUnlockService` to disable bronzeman features on unsupported worlds (Deadman, Seasonal, etc.).
+
+**Design spec:** [world-type-policy-support.md](../designs/world-type-policy-support.md)
+**Security reviews:** None
+
+## Prerequisites
+
+- [ ] None
+
+---
+
+## Phase 1: Create WorldTypeService
+
+### Task 1.1: Create WorldTypeService class
+
+**Context:** Central service for world type checking, replacing scattered logic in ItemUnlockService. Note: `BOUNTY` is a net-new addition (not in existing `ItemUnlockService.supportedWorldTypes`).
+
+**Files:**
+- Create: `src/main/java/com.elertan/WorldTypeService.java`
+
+**Requirements:**
+- `@Singleton` annotation
+- Implement `BUPluginLifecycle` with empty `startUp()`/`shutDown()`
+- Inject `Client`
+- Define `SUPPORTED_WORLD_TYPES` using `Set.of()` with: `MEMBERS`, `PVP`, `BOUNTY`, `SKILL_TOTAL`, `HIGH_RISK`, `FRESH_START_WORLD`, `LAST_MAN_STANDING`
+- Use `net.runelite.api.WorldType` (client API, not HTTP API). Note: this is a different enum than `net.runelite.http.api.worlds.WorldType` - verify all constants exist.
+- Implement `isCurrentWorldSupported()` with javadoc noting client thread requirement:
+  ```java
+  /**
+   * Checks if the current world type is supported for bronzeman features.
+   * Must be called from client thread.
+   *
+   * @return true if policies and unlocks should apply, false otherwise
+   */
+  public boolean isCurrentWorldSupported() {
+      EnumSet<WorldType> worldTypes = client.getWorldType();
+      // Empty set returns true (vacuous truth via allMatch), which is expected
+      return worldTypes.stream().allMatch(SUPPORTED_WORLD_TYPES::contains);
+  }
+  ```
+
+**Acceptance Criteria:**
+- [ ] Class compiles without errors
+- [ ] Uses `net.runelite.api.WorldType` import
+- [ ] `SUPPORTED_WORLD_TYPES` contains all 7 world types including `BOUNTY`
+- [ ] Javadoc documents client thread requirement
+
+**Dependencies:** None
+
+---
+
+## Phase 2: Integrate into PolicyBase
+
+### Task 2.1: Add WorldTypeService to PolicyBase
+
+**Context:** PolicyBase.createContext() needs to check world type before applying any policy rules.
+
+**Files:**
+- Modify: `src/main/java/com.elertan/policies/PolicyBase.java` - inject WorldTypeService, update createContext()
+
+**Requirements:**
+- Add `WorldTypeService` field (passed via constructor, not `@Inject` on field)
+- Add `WorldTypeService` parameter to constructor
+- In `createContext()`: add early check at the start of the method. If `!worldTypeService.isCurrentWorldSupported()`:
+  - Log at debug level: `log.debug("Skipping policy - unsupported world type")`
+  - Return `new PolicyContext(null, false)` (gameRules=null, mustEnforceStrictPolicies=false → shouldApplyForRules returns false)
+- Note: This returns the same context as "no account config" case, but the log message distinguishes them for debugging
+
+**Acceptance Criteria:**
+- [ ] PolicyBase compiles without errors
+- [ ] `createContext()` returns non-enforcing context on unsupported worlds
+- [ ] Debug log message added for unsupported world case
+- [ ] Existing policy behavior unchanged on supported worlds
+
+**Dependencies:** Task 1.1
+
+### Task 2.2: Update all policy constructors
+
+**Context:** All policies extend PolicyBase and must pass WorldTypeService to super constructor. Verify complete list by searching for `extends PolicyBase`.
+
+**Files:**
+- Modify: `src/main/java/com.elertan/policies/GrandExchangePolicy.java`
+- Modify: `src/main/java/com.elertan/policies/TradePolicy.java`
+- Modify: `src/main/java/com.elertan/policies/ShopPolicy.java`
+- Modify: `src/main/java/com.elertan/policies/GroundItemsPolicy.java`
+- Modify: `src/main/java/com.elertan/policies/PlayerOwnedHousePolicy.java`
+- Modify: `src/main/java/com.elertan/policies/PlayerVersusPlayerPolicy.java`
+- Modify: `src/main/java/com.elertan/policies/FaladorPartyRoomPolicy.java`
+
+**Requirements:**
+- Add `WorldTypeService` parameter to each policy constructor
+- Pass `WorldTypeService` to `super()` call
+
+**Acceptance Criteria:**
+- [ ] All 7 policies compile without errors
+- [ ] Each policy passes WorldTypeService to PolicyBase constructor
+- [ ] Verified no other classes extend PolicyBase (search: `extends PolicyBase`)
+
+**Dependencies:** Task 2.1
+
+### CHECKPOINT
+
+Gate: All policies compile, createContext() returns non-enforcing context on unsupported worlds.
+
+---
+
+## Phase 3: Migrate ItemUnlockService
+
+### Task 3.1: Replace world type checking in ItemUnlockService
+
+**Context:** ItemUnlockService currently uses WorldService (HTTP API) and has its own supportedWorldTypes constant. Replace with WorldTypeService.
+
+**Files:**
+- Modify: `src/main/java/com.elertan/ItemUnlockService.java`
+
+**Requirements:**
+Order of operations: First add new injection, then update call sites, then remove old code.
+
+1. Add `@Inject WorldTypeService worldTypeService`
+2. In `unlockItem()`: replace `isCurrentWorldSupportedForUnlockingItems()` call with `worldTypeService.isCurrentWorldSupported()`
+3. In `checkAndNotifyNonSupportedWorldType()`: replace `isCurrentWorldSupportedForUnlockingItems()` call with `worldTypeService.isCurrentWorldSupported()`
+4. Remove `private boolean isCurrentWorldSupportedForUnlockingItems()` method
+5. Remove `private static final Set<WorldType> supportedWorldTypes` constant
+6. Remove `WorldService` injection (confirmed: only used in the removed method)
+7. Remove unused imports: `net.runelite.http.api.worlds.WorldType`, `net.runelite.http.api.worlds.WorldResult`, `net.runelite.http.api.worlds.World`
+
+**Acceptance Criteria:**
+- [ ] ItemUnlockService compiles without errors
+- [ ] No HTTP API world type imports remain
+- [ ] `supportedWorldTypes` constant removed
+- [ ] `isCurrentWorldSupportedForUnlockingItems()` method removed
+- [ ] `WorldService` injection removed
+- [ ] Both call sites use `worldTypeService.isCurrentWorldSupported()`
+
+**Dependencies:** Task 1.1
+
+### CHECKPOINT
+
+Gate: Full build succeeds, all changes integrated.
+
+---
+
+## Completion Checklist
+
+- [ ] All tasks completed
+- [ ] Full build succeeds (`./gradlew build`)
+- [ ] Design spec success criteria met:
+  - [ ] Policies do not apply on unsupported world types
+  - [ ] BOUNTY added to supported world types
+  - [ ] Switch from WorldService (HTTP API) to client.getWorldType() (client API)
+  - [ ] Single source of truth for supported world types via WorldTypeService
+
+## Manual Testing
+
+- [ ] Log into Deadman world → verify policies don't block actions (ground item pickup, trading)
+- [ ] Log into normal Members world → verify policies still work
+- [ ] Log into world with multiple types (e.g., Members + Skill Total) → verify supported
+- [ ] Verify item unlocks still blocked on Deadman world (existing behavior preserved)

--- a/src/main/java/com.elertan/ItemUnlockService.java
+++ b/src/main/java/com.elertan/ItemUnlockService.java
@@ -22,10 +22,6 @@ import net.runelite.client.events.ServerNpcLoot;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemMapping;
 import net.runelite.client.game.ItemStack;
-import net.runelite.client.game.WorldService;
-import net.runelite.http.api.worlds.World;
-import net.runelite.http.api.worlds.WorldResult;
-import net.runelite.http.api.worlds.WorldType;
 
 import com.elertan.utils.Subscription;
 import java.time.OffsetDateTime;
@@ -125,22 +121,12 @@ public class ItemUnlockService implements BUPluginLifecycle {
         InventoryID.LOOTING_BAG, // Looting bag
         InventoryID.PMOON_REWARDINV // Moons of Peril reward
     );
-    private static final Set<WorldType> supportedWorldTypes = ImmutableSet.of(
-        WorldType.MEMBERS,
-        WorldType.PVP,
-        WorldType.SKILL_TOTAL,
-        WorldType.HIGH_RISK,
-        WorldType.FRESH_START_WORLD,
-        WorldType.LAST_MAN_STANDING
-    );
     private Subscription stateSubscription;
     private Subscription accountConfigSubscription;
     @Inject
     private Client client;
     @Inject
     private ClientThread clientThread;
-    @Inject
-    private WorldService worldService;
     @Inject
     private ItemManager itemManager;
     @Inject
@@ -163,6 +149,8 @@ public class ItemUnlockService implements BUPluginLifecycle {
     private MinigameService minigameService;
     @Inject
     private CollectionLogService collectionLogService;
+    @Inject
+    private WorldTypeService worldTypeService;
     private UnlockedItemsDataProvider.UnlockedItemsMapListener unlockedItemsMapListener;
     private volatile boolean hasNotifiedPlayerOfNonSupportedWorldType = false;
 
@@ -439,12 +427,7 @@ public class ItemUnlockService implements BUPluginLifecycle {
     }
 
     private void checkAndNotifyNonSupportedWorldType() {
-        boolean isSupported;
-        try {
-            isSupported = isCurrentWorldSupportedForUnlockingItems();
-        } catch (Exception e) {
-            return;
-        }
+        boolean isSupported = worldTypeService.isCurrentWorldSupported();
 
         if (isSupported) {
             return;
@@ -469,13 +452,9 @@ public class ItemUnlockService implements BUPluginLifecycle {
         }
 
         // We don't support all world types, for example we don't want unlocks on seasonal modes
-        try {
-            if (!isCurrentWorldSupportedForUnlockingItems()) {
-                log.info("Current world is not supported for unlocking items");
-                return CompletableFuture.completedFuture(null);
-            }
-        } catch (Exception ex) {
-            return CompletableFuture.failedFuture(ex);
+        if (!worldTypeService.isCurrentWorldSupported()) {
+            log.info("Current world is not supported for unlocking items");
+            return CompletableFuture.completedFuture(null);
         }
 
         // Disable LMS unlocks
@@ -557,23 +536,6 @@ public class ItemUnlockService implements BUPluginLifecycle {
         // essentially the same item
         String itemName = client.getItemDefinition(itemId).getName();
         return MAP_ITEM_NAMES.getOrDefault(itemName, itemId);
-    }
-
-    private boolean isCurrentWorldSupportedForUnlockingItems() throws Exception {
-        int worldNumber = client.getWorld();
-        WorldResult worldResult = worldService.getWorlds();
-        if (worldResult == null) {
-            throw new Exception("Failed to get worlds");
-        }
-        World world = worldResult.findWorld(worldNumber);
-        if (world == null) {
-            throw new Exception("Failed to find world with id " + worldNumber);
-        }
-        EnumSet<WorldType> worldTypes = world.getTypes();
-        boolean hasUnsupportedWorldType = !worldTypes.isEmpty() && worldTypes.stream()
-            .anyMatch(t -> !supportedWorldTypes.contains(t));
-
-        return !hasUnsupportedWorldType;
     }
 
     private void unlockedItemDataProviderStateListener(AbstractDataProvider.State state) {

--- a/src/main/java/com.elertan/WorldTypeService.java
+++ b/src/main/java/com.elertan/WorldTypeService.java
@@ -1,0 +1,45 @@
+package com.elertan;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.EnumSet;
+import java.util.Set;
+import net.runelite.api.Client;
+import net.runelite.api.WorldType;
+
+@Singleton
+public class WorldTypeService implements BUPluginLifecycle {
+
+    private static final Set<WorldType> SUPPORTED_WORLD_TYPES = Set.of(
+        WorldType.MEMBERS,
+        WorldType.PVP,
+        WorldType.BOUNTY,
+        WorldType.SKILL_TOTAL,
+        WorldType.HIGH_RISK,
+        WorldType.FRESH_START_WORLD,
+        WorldType.LAST_MAN_STANDING
+    );
+
+    @Inject
+    private Client client;
+
+    @Override
+    public void startUp() throws Exception {
+    }
+
+    @Override
+    public void shutDown() throws Exception {
+    }
+
+    /**
+     * Checks if the current world type is supported for bronzeman features.
+     * Must be called from client thread.
+     *
+     * @return true if policies and unlocks should apply, false otherwise
+     */
+    public boolean isCurrentWorldSupported() {
+        EnumSet<WorldType> worldTypes = client.getWorldType();
+        // Empty set returns true (vacuous truth via allMatch), which is expected
+        return worldTypes.stream().allMatch(SUPPORTED_WORLD_TYPES::contains);
+    }
+}

--- a/src/main/java/com.elertan/policies/FaladorPartyRoomPolicy.java
+++ b/src/main/java/com.elertan/policies/FaladorPartyRoomPolicy.java
@@ -5,6 +5,7 @@ import com.elertan.BUChatService;
 import com.elertan.BUPluginConfig;
 import com.elertan.GameRulesService;
 import com.elertan.PolicyService;
+import com.elertan.WorldTypeService;
 import com.elertan.chat.ChatMessageProvider;
 import com.elertan.chat.ChatMessageProvider.MessageKey;
 import com.elertan.models.GameRules;
@@ -28,8 +29,9 @@ public class FaladorPartyRoomPolicy extends PolicyBase {
 
     @Inject
     public FaladorPartyRoomPolicy(AccountConfigurationService accountConfigurationService,
-        GameRulesService gameRulesService, PolicyService policyService) {
-        super(accountConfigurationService, gameRulesService, policyService);
+        GameRulesService gameRulesService, PolicyService policyService,
+        WorldTypeService worldTypeService) {
+        super(accountConfigurationService, gameRulesService, policyService, worldTypeService);
     }
 
     public void onMenuOptionClicked(MenuOptionClicked event) {

--- a/src/main/java/com.elertan/policies/GrandExchangePolicy.java
+++ b/src/main/java/com.elertan/policies/GrandExchangePolicy.java
@@ -4,6 +4,7 @@ import com.elertan.AccountConfigurationService;
 import com.elertan.GameRulesService;
 import com.elertan.ItemUnlockService;
 import com.elertan.PolicyService;
+import com.elertan.WorldTypeService;
 import com.elertan.models.GameRules;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -32,9 +33,10 @@ public class GrandExchangePolicy extends PolicyBase {
     @Inject
     public GrandExchangePolicy(
         AccountConfigurationService accountConfigurationService,
-        GameRulesService gameRulesService, PolicyService policyService
+        GameRulesService gameRulesService, PolicyService policyService,
+        WorldTypeService worldTypeService
     ) {
-        super(accountConfigurationService, gameRulesService, policyService);
+        super(accountConfigurationService, gameRulesService, policyService, worldTypeService);
     }
 
     @Override

--- a/src/main/java/com.elertan/policies/GroundItemsPolicy.java
+++ b/src/main/java/com.elertan/policies/GroundItemsPolicy.java
@@ -9,6 +9,7 @@ import com.elertan.GameRulesService;
 import com.elertan.MemberService;
 import com.elertan.MinigameService;
 import com.elertan.PolicyService;
+import com.elertan.WorldTypeService;
 import com.elertan.chat.ChatMessageProvider;
 import com.elertan.chat.ChatMessageProvider.MessageKey;
 import com.elertan.data.GroundItemOwnedByDataProvider;
@@ -72,8 +73,9 @@ public class GroundItemsPolicy extends PolicyBase implements BUPluginLifecycle {
 
     @Inject
     public GroundItemsPolicy(AccountConfigurationService accountConfigurationService,
-        GameRulesService gameRulesService, PolicyService policyService) {
-        super(accountConfigurationService, gameRulesService, policyService);
+        GameRulesService gameRulesService, PolicyService policyService,
+        WorldTypeService worldTypeService) {
+        super(accountConfigurationService, gameRulesService, policyService, worldTypeService);
     }
 
     @Override

--- a/src/main/java/com.elertan/policies/PlayerOwnedHousePolicy.java
+++ b/src/main/java/com.elertan/policies/PlayerOwnedHousePolicy.java
@@ -8,6 +8,7 @@ import com.elertan.BUSoundHelper;
 import com.elertan.GameRulesService;
 import com.elertan.MemberService;
 import com.elertan.PolicyService;
+import com.elertan.WorldTypeService;
 import com.elertan.chat.ChatMessageProvider;
 import com.elertan.chat.ChatMessageProvider.MessageKey;
 import com.elertan.models.GameRules;
@@ -63,8 +64,9 @@ public class PlayerOwnedHousePolicy extends PolicyBase implements BUPluginLifecy
 
     @Inject
     public PlayerOwnedHousePolicy(AccountConfigurationService accountConfigurationService,
-        GameRulesService gameRulesService, PolicyService policyService) {
-        super(accountConfigurationService, gameRulesService, policyService);
+        GameRulesService gameRulesService, PolicyService policyService,
+        WorldTypeService worldTypeService) {
+        super(accountConfigurationService, gameRulesService, policyService, worldTypeService);
     }
 
     @Override

--- a/src/main/java/com.elertan/policies/PlayerVersusPlayerPolicy.java
+++ b/src/main/java/com.elertan/policies/PlayerVersusPlayerPolicy.java
@@ -8,6 +8,7 @@ import com.elertan.BUSoundHelper;
 import com.elertan.GameRulesService;
 import com.elertan.MinigameService;
 import com.elertan.PolicyService;
+import com.elertan.WorldTypeService;
 import com.elertan.chat.ChatMessageProvider;
 import com.elertan.chat.ChatMessageProvider.MessageKey;
 import com.elertan.data.GroundItemOwnedByDataProvider;
@@ -64,8 +65,9 @@ public class PlayerVersusPlayerPolicy extends PolicyBase implements BUPluginLife
 
     @Inject
     public PlayerVersusPlayerPolicy(AccountConfigurationService accountConfigurationService,
-        GameRulesService gameRulesService, PolicyService policyService) {
-        super(accountConfigurationService, gameRulesService, policyService);
+        GameRulesService gameRulesService, PolicyService policyService,
+        WorldTypeService worldTypeService) {
+        super(accountConfigurationService, gameRulesService, policyService, worldTypeService);
     }
 
     @Override

--- a/src/main/java/com.elertan/policies/PolicyBase.java
+++ b/src/main/java/com.elertan/policies/PolicyBase.java
@@ -4,6 +4,7 @@ import com.elertan.AccountConfigurationService;
 import com.elertan.BUPluginLifecycle;
 import com.elertan.GameRulesService;
 import com.elertan.PolicyService;
+import com.elertan.WorldTypeService;
 import com.elertan.models.AccountConfiguration;
 import com.elertan.models.GameRules;
 import java.util.function.Function;
@@ -18,12 +19,15 @@ public class PolicyBase implements BUPluginLifecycle {
     protected final AccountConfigurationService accountConfigurationService;
     protected final GameRulesService gameRulesService;
     protected final PolicyService policyService;
+    protected final WorldTypeService worldTypeService;
 
     public PolicyBase(AccountConfigurationService accountConfigurationService,
-        GameRulesService gameRulesService, PolicyService policyService) {
+        GameRulesService gameRulesService, PolicyService policyService,
+        WorldTypeService worldTypeService) {
         this.accountConfigurationService = accountConfigurationService;
         this.gameRulesService = gameRulesService;
         this.policyService = policyService;
+        this.worldTypeService = worldTypeService;
     }
 
     @Override
@@ -37,6 +41,12 @@ public class PolicyBase implements BUPluginLifecycle {
     @NonNull
     protected PolicyContext createContext() {
         log.debug("creating context from class: {}", this.getClass().getName());
+
+        if (!worldTypeService.isCurrentWorldSupported()) {
+            log.debug("Skipping policy - unsupported world type");
+            return new PolicyContext(null, false);
+        }
+
         AccountConfiguration accountConfiguration = null;
         try {
             accountConfiguration = accountConfigurationService.getCurrentAccountConfiguration();

--- a/src/main/java/com.elertan/policies/ShopPolicy.java
+++ b/src/main/java/com.elertan/policies/ShopPolicy.java
@@ -6,6 +6,7 @@ import com.elertan.BUResourceService;
 import com.elertan.GameRulesService;
 import com.elertan.ItemUnlockService;
 import com.elertan.PolicyService;
+import com.elertan.WorldTypeService;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.awt.AlphaComposite;
@@ -48,8 +49,9 @@ public class ShopPolicy extends PolicyBase {
 
     @Inject
     public ShopPolicy(AccountConfigurationService accountConfigurationService,
-        GameRulesService gameRulesService, PolicyService policyService) {
-        super(accountConfigurationService, gameRulesService, policyService);
+        GameRulesService gameRulesService, PolicyService policyService,
+        WorldTypeService worldTypeService) {
+        super(accountConfigurationService, gameRulesService, policyService, worldTypeService);
     }
 
     public void onWidgetLoaded(WidgetLoaded event) {

--- a/src/main/java/com.elertan/policies/TradePolicy.java
+++ b/src/main/java/com.elertan/policies/TradePolicy.java
@@ -8,6 +8,7 @@ import com.elertan.GameRulesService;
 import com.elertan.ItemUnlockService;
 import com.elertan.MemberService;
 import com.elertan.PolicyService;
+import com.elertan.WorldTypeService;
 import com.elertan.models.GameRules;
 import com.elertan.models.Member;
 import com.elertan.utils.TextUtils;
@@ -35,8 +36,9 @@ public class TradePolicy extends PolicyBase {
 
     @Inject
     public TradePolicy(AccountConfigurationService accountConfigurationService,
-        GameRulesService gameRulesService, PolicyService policyService) {
-        super(accountConfigurationService, gameRulesService, policyService);
+        GameRulesService gameRulesService, PolicyService policyService,
+        WorldTypeService worldTypeService) {
+        super(accountConfigurationService, gameRulesService, policyService, worldTypeService);
     }
 
     public void onMenuOptionClicked(MenuOptionClicked event) {


### PR DESCRIPTION
## Summary
- Add `WorldTypeService` to centralize world type checking
- Policies now skip enforcement on unsupported worlds (Deadman, Seasonal, Beta, etc.)
- Switch from HTTP API (`WorldService`) to client API (`client.getWorldType()`)
- Add `BOUNTY` to supported world types (main game with minigame access)

## Problem
Policies incorrectly enforce restrictions on special world types like Deadman Mode. Item unlocks were correctly blocked, but policies (ground item pickup, trading, etc.) still applied where they shouldn't.

## Changes
- **New:** `WorldTypeService` - single source of truth for supported world types
- **Modified:** `PolicyBase.createContext()` - early return for unsupported worlds
- **Modified:** All 7 policies - pass `WorldTypeService` to base constructor
- **Modified:** `ItemUnlockService` - use `WorldTypeService` instead of HTTP API

## Test plan
- [ ] Log into Deadman world → verify policies don't block actions
- [ ] Log into normal Members world → verify policies still work
- [ ] Verify item unlocks still blocked on Deadman world