### PR TITLE
fix(grand-exchange): block locked items via previous search

### DIFF
--- a/src/main/java/com.elertan/BUPlugin.java
+++ b/src/main/java/com.elertan/BUPlugin.java
@@ -311,6 +311,7 @@ public final class BUPlugin extends Plugin {
 
     @Subscribe
     public void onMenuOptionClicked(MenuOptionClicked event) {
+        grandExchangePolicy.onMenuOptionClicked(event);
         tradePolicy.onMenuOptionClicked(event);
         groundItemsPolicy.onMenuOptionClicked(event);
         playerOwnedHousePolicy.onMenuOptionClicked(event);

--- a/src/main/java/com.elertan/policies/GrandExchangePolicy.java
+++ b/src/main/java/com.elertan/policies/GrandExchangePolicy.java
@@ -11,6 +11,8 @@ import com.google.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.ScriptID;
+import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ScriptPostFired;
 import net.runelite.api.events.WidgetClosed;
@@ -22,12 +24,16 @@ import net.runelite.api.widgets.Widget;
 @Singleton
 public class GrandExchangePolicy extends PolicyBase {
 
+    // Script 751 fires when typing in the search box, 752 fires for the "show last searched" row.
     private final static int GE_SEARCH_BUILD_SCRIPT_ID = 751;
+    private static final int GE_ITEM_SEARCH_SCRIPT_ID = ScriptID.GE_ITEM_SEARCH;
+
     @Inject
     private Client client;
     @Inject
     private ItemUnlockService itemUnlockService;
 
+    // Only process script events when the GE is actually open
     private boolean geInterfaceOpen;
 
     @Inject
@@ -62,22 +68,68 @@ public class GrandExchangePolicy extends PolicyBase {
         }
     }
 
+    // Re-apply locked-item styling whenever the GE search results get rebuilt
     public void onScriptPostFired(ScriptPostFired event) {
         if (!accountConfigurationService.isBronzemanEnabled()) {
             return;
         }
 
-        if (!geInterfaceOpen)
-        {
+        if (!geInterfaceOpen) {
             return;
         }
 
         int scriptId = event.getScriptId();
-        if (scriptId == GE_SEARCH_BUILD_SCRIPT_ID) {
+        if (scriptId == GE_SEARCH_BUILD_SCRIPT_ID || scriptId == GE_ITEM_SEARCH_SCRIPT_ID) {
             onSearchBuild();
         }
     }
 
+    // Backup click blocking in case the visual hide didn't catch it (race conditions etc)
+    public void onMenuOptionClicked(MenuOptionClicked event) {
+        if (!accountConfigurationService.isBronzemanEnabled()) {
+            return;
+        }
+
+        if (!geInterfaceOpen) {
+            return;
+        }
+
+        PolicyContext context = createContext();
+        if (!context.shouldApplyForRules(GameRules::isPreventGrandExchangeBuyOffers)) {
+            return;
+        }
+
+        Widget clickedWidget = resolveClickedWidget(event);
+        if (clickedWidget == null) {
+            return;
+        }
+
+        Integer itemId = resolveSearchResultItemId(clickedWidget);
+        if (itemId == null || itemId <= 0) {
+            return;
+        }
+
+        final boolean hasUnlockedItem;
+        try {
+            hasUnlockedItem = itemUnlockService.hasUnlockedItem(itemId);
+        } catch (Exception e) {
+            log.error("Failed to check hasUnlockedItem({}) in onMenuOptionClicked", itemId, e);
+            return;
+        }
+
+        // Block the click if the item isn't unlocked
+        if (!hasUnlockedItem) {
+            event.consume();
+        }
+    }
+
+    // Grey out and disable locked items in the GE search results.
+    //
+    // Widget layout (dynamic children of 162.51 MES_LAYER_SCROLLCONTENTS):
+    //   "Previous search" row = 5 children: [0] clickable, [1] text, [2] bg, [3] item icon, [4] separator
+    //   Typed search rows    = 3 children each: [i] clickable, [i+1] name, [i+2] item icon
+    //
+    // We detect the previous-search row via modulo: with it present length%3==2, without it length%3==0.
     private void onSearchBuild() {
         PolicyContext context = createContext();
         if (!context.shouldApplyForRules(GameRules::isPreventGrandExchangeBuyOffers)) {
@@ -86,38 +138,148 @@ public class GrandExchangePolicy extends PolicyBase {
 
         Widget searchResultsWidget = client.getWidget(InterfaceID.Chatbox.MES_LAYER_SCROLLCONTENTS);
         if (searchResultsWidget == null) {
-            log.error("Search results widget is null onGrandExchangeSearchBuild");
             return;
         }
 
         final Widget[] children = searchResultsWidget.getDynamicChildren();
-        if (children == null || children.length < 2 || children.length % 3 != 0) {
+        if (children == null || children.length < 3) {
             return;
         }
 
-        for (int i = 0; i < children.length; i += 3) {
-            final Widget itemWidget = children[i + 2];
-            final int itemId = itemWidget.getItemId();
-            final boolean hasUnlockedItem;
-            try {
-                hasUnlockedItem = itemUnlockService.hasUnlockedItem(itemId);
-            } catch (Exception e) {
-                log.error(
-                    "Failed to check hasUnlockedItem({}) in onGrandExchangeSearchBuild",
-                    itemId,
-                    e
-                );
-                return;
-            }
+        int startIndex = 0;
+        boolean hasPreviousSearchRow = children.length >= 5 && children.length % 3 == 2;
 
-            if (!hasUnlockedItem) {
-                // Make not clickable
-                children[i].setHidden(true);
+        if (hasPreviousSearchRow) {
+            // Previous search row: clickable at [0], item icon at [3]
+            applyLockedRowStyling(children, 0, 3, 5);
+            startIndex = 5;
+        }
 
-                // Make transparent to indicate not clickable
-                children[i + 1].setOpacity(120);
-                children[i + 2].setOpacity(120);
+        // Typed rows: 3 children each, clickable at [i], item icon at [i+2]
+        for (int i = startIndex; i + 2 < children.length; i += 3) {
+            applyLockedRowStyling(children, i, i + 2, 3);
+        }
+    }
+
+    // Hides the clickable widget and dims the row if the item is locked
+    private void applyLockedRowStyling(
+        Widget[] children,
+        int clickableIndex,
+        int itemIndex,
+        int rowChildCount
+    ) {
+        Widget clickableWidget = children[clickableIndex];
+        Widget itemWidget = children[itemIndex];
+        if (clickableWidget == null || itemWidget == null) {
+            return;
+        }
+
+        final int itemId = itemWidget.getItemId();
+        if (itemId <= 0) {
+            return;
+        }
+
+        final boolean hasUnlockedItem;
+        try {
+            hasUnlockedItem = itemUnlockService.hasUnlockedItem(itemId);
+        } catch (Exception e) {
+            log.error("Failed to check hasUnlockedItem({}) in onGrandExchangeSearchBuild", itemId, e);
+            return;
+        }
+
+        if (hasUnlockedItem) {
+            return;
+        }
+
+        clickableWidget.setHidden(true);
+
+        // Dim the rest of the row so it looks visually locked
+        int rowEndExclusive = Math.min(clickableIndex + rowChildCount, children.length);
+        for (int i = clickableIndex + 1; i < rowEndExclusive; i++) {
+            Widget rowWidget = children[i];
+            if (rowWidget != null) {
+                rowWidget.setOpacity(120);
             }
         }
+    }
+
+    // event.getWidget() is sometimes null, so fall back to looking it up via param1/param0
+    private Widget resolveClickedWidget(MenuOptionClicked event) {
+        Widget widget = event.getWidget();
+        if (widget != null) {
+            return widget;
+        }
+
+        Widget rootWidget = client.getWidget(event.getParam1());
+        if (rootWidget == null) {
+            return null;
+        }
+
+        int childIndex = event.getParam0();
+        if (childIndex < 0) {
+            return rootWidget;
+        }
+
+        Widget childWidget = rootWidget.getChild(childIndex);
+        return childWidget != null ? childWidget : rootWidget;
+    }
+
+    // Walk up from the clicked widget to the scroll container, figure out which row
+    // was clicked, and return the item ID for that row.
+    private Integer resolveSearchResultItemId(Widget clickedWidget) {
+        Widget anchorWidget = clickedWidget;
+        Widget parent = anchorWidget.getParent();
+        while (parent != null && parent.getId() != InterfaceID.Chatbox.MES_LAYER_SCROLLCONTENTS) {
+            anchorWidget = parent;
+            parent = anchorWidget.getParent();
+        }
+
+        if (parent == null) {
+            return null;
+        }
+
+        // Now find which dynamic child index corresponds to our clicked widget.
+        Widget[] siblings = parent.getDynamicChildren();
+        if (siblings == null || siblings.length < 3) {
+            return null;
+        }
+
+        int clickedIndex = -1;
+        for (int i = 0; i < siblings.length; i++) {
+            Widget sibling = siblings[i];
+            if (sibling == anchorWidget || (sibling != null && sibling.getId() == anchorWidget.getId())) {
+                clickedIndex = i;
+                break;
+            }
+        }
+
+        if (clickedIndex < 0) {
+            return null;
+        }
+
+        // Same modulo check as onSearchBuild — previous search row = first 5 kids, item at [3]
+        boolean hasPreviousSearchRow = siblings.length >= 5 && siblings.length % 3 == 2;
+        if (hasPreviousSearchRow && clickedIndex <= 4) {
+            Widget itemWidget = siblings[3];
+            return itemWidget != null ? itemWidget.getItemId() : null;
+        }
+
+        // For typed rows, find which 3-child group this click is in, item is at offset +2
+        int itemIndex;
+        if (hasPreviousSearchRow) {
+            // Skip past the 5 previous-search children
+            int rowStart = 5 + ((clickedIndex - 5) / 3) * 3;
+            itemIndex = rowStart + 2;
+        } else {
+            int rowStart = (clickedIndex / 3) * 3;
+            itemIndex = rowStart + 2;
+        }
+
+        if (itemIndex < 0 || itemIndex >= siblings.length) {
+            return null;
+        }
+
+        Widget itemWidget = siblings[itemIndex];
+        return itemWidget != null ? itemWidget.getItemId() : null;
     }
 }


### PR DESCRIPTION

Closes #17

## Acceptance criteria

- [x] **Locked items are consistently blocked in recent searches.**  
  Recent-search row is greyed out and non-clickable for locked items; "Create Buy offer" and "Select" are blocked in `onMenuOptionClicked` when the item is locked (including when the click is on the previous-search row).

  <img width="1024" height="340" alt="locked" src="https://github.com/user-attachments/assets/7807e35e-e9e1-4497-a82f-9f74d8bd39f7" />

- [x] **Behavior matches normal GE search-result restrictions.**  
  Same blocking and dimming logic applies to both the previous-search row and typed search results (previous-search row: [0]=clickable area, [3]=item icon; typed rows: 3-per-row with item at `i+2`).

  <img width="908" height="241" alt="proof" src="https://github.com/user-attachments/assets/8fca79f5-2a30-4f8e-8e74-18046f7cb356" />

- [x] **No regression for unlocked items.**  
  Unlocked items remain clickable and visible in both recent search and search results.

  <img width="1024" height="340" alt="unlocked" src="https://github.com/user-attachments/assets/15404c0f-507d-4191-83d7-f87f6e150d07" />

- [x] **UI state updates correctly when unlock state changes.**  
  `onSearchBuild` runs on the GE search build script (ScriptPostFired); when the list is rebuilt, locked items are dimmed/hidden and unlocked items are shown normally, so UI reflects current unlock state.

---

## Implementation summary

- Handle menu options in `GrandExchangePolicy`: block "Create Buy offer" and "Select" for locked items (including previous-search row).
- Resolve item ID from search widget layout: previous-search row uses [0]=clickable area, [3]=item icon; grey out [0] and dim row when locked.
- Dim locked items in both previous-search row and typed search results in `onSearchBuild` (ScriptPostFired for GE search build script).