### PR TITLE
fix: address reviewer feedback on logging, http client, and shop overlay

### DIFF
--- a/src/main/java/com.elertan/BUChatService.java
+++ b/src/main/java/com.elertan/BUChatService.java
@@ -140,7 +140,7 @@ public class BUChatService implements BUPluginLifecycle {
         }
 
         withErrorLogging(buEventService.publishEvent(event), "error publishing game message event")
-            .thenRun(() -> log.info("published game message event"));
+            .thenRun(() -> log.debug("published game message event"));
     }
 
     public void onScriptCallbackEvent(ScriptCallbackEvent scriptCallbackEvent) {

--- a/src/main/java/com.elertan/BUCommandService.java
+++ b/src/main/java/com.elertan/BUCommandService.java
@@ -89,7 +89,7 @@ public class BUCommandService implements BUPluginLifecycle {
         String commandName = args[0].toLowerCase();
         String argument = args.length > 1 ? args[1] : null;
 
-        log.info("Parsed command: '{}', argument: '{}'", commandName, argument);
+        log.debug("Parsed command: '{}', argument: '{}'", commandName, argument);
 
         Stream<CommandInfo> commandStream = config.enableDebugCommands()
             ? Stream.concat(commands.stream(), debugCommands.stream())

--- a/src/main/java/com.elertan/ItemUnlockService.java
+++ b/src/main/java/com.elertan/ItemUnlockService.java
@@ -411,7 +411,7 @@ public class ItemUnlockService implements BUPluginLifecycle {
         }
 
         return unlockedItemsDataProvider.removeUnlockedItemById(itemId)
-            .thenRun(() -> log.info("Removed unlocked item with id {}", itemId));
+            .thenRun(() -> log.debug("Removed unlocked item with id {}", itemId));
     }
 
     private boolean unlockedItemsDataProviderNotReady() {
@@ -453,7 +453,7 @@ public class ItemUnlockService implements BUPluginLifecycle {
 
         // We don't support all world types, for example we don't want unlocks on seasonal modes
         if (!worldTypeService.isCurrentWorldSupported()) {
-            log.info("Current world is not supported for unlocking items");
+            log.debug("Current world is not supported for unlocking items");
             return CompletableFuture.completedFuture(null);
         }
 
@@ -509,7 +509,7 @@ public class ItemUnlockService implements BUPluginLifecycle {
                     acquiredAt,
                     droppedByNPCId
                 );
-                log.info("Unlocked item ({}) '{}'", fItemId, fItemName);
+                log.debug("Unlocked item ({}) '{}'", fItemId, fItemName);
                 return unlockedItemsDataProvider.addUnlockedItem(unlockedItem);
             });
     }

--- a/src/main/java/com.elertan/LootValuationService.java
+++ b/src/main/java/com.elertan/LootValuationService.java
@@ -81,7 +81,7 @@ public class LootValuationService implements BUPluginLifecycle {
                         log.error("error publishing valuable loot event", throwable);
                         return;
                     }
-                    log.info("published valuable loot event");
+                    log.debug("published valuable loot event");
                 });
             }
         }

--- a/src/main/java/com.elertan/MemberService.java
+++ b/src/main/java/com.elertan/MemberService.java
@@ -220,7 +220,7 @@ public class MemberService implements BUPluginLifecycle {
             Member member = membersMap.get(accountHash);
             String memberName = member.getName();
             if (memberName == null || !memberName.equals(name)) {
-                log.info(
+                log.debug(
                     "member service -> name changed from '{}' to '{}' issue-ing member update",
                     memberName,
                     name
@@ -236,7 +236,7 @@ public class MemberService implements BUPluginLifecycle {
         );
 
         if (shouldUpdateMember) {
-            log.info("adding member...");
+            log.debug("adding member...");
             ISOOffsetDateTime now = new ISOOffsetDateTime(OffsetDateTime.now());
 
             MemberRole memberRole = shouldBeOwner ? MemberRole.Owner : MemberRole.Member;
@@ -252,7 +252,7 @@ public class MemberService implements BUPluginLifecycle {
                     log.error("member service error whilst adding member", addMemberThrowable);
                     return;
                 }
-                log.info("member added!");
+                log.debug("member added!");
             });
         }
     }

--- a/src/main/java/com.elertan/data/MembersDataProvider.java
+++ b/src/main/java/com.elertan/data/MembersDataProvider.java
@@ -37,7 +37,7 @@ public class MembersDataProvider extends AbstractDataProvider {
         storagePortListener = new KeyValueStoragePort.Listener<Long, Member>() {
             @Override
             public void onFullUpdate(Map<Long, Member> map) {
-                log.info("members data provider -> on full update");
+                log.debug("members data provider -> on full update");
                 if (membersMap == null) {
                     return;
                 }
@@ -46,7 +46,7 @@ public class MembersDataProvider extends AbstractDataProvider {
 
             @Override
             public void onUpdate(Long key, Member member) {
-                log.info("members data provider -> on update");
+                log.debug("members data provider -> on update");
                 if (membersMap == null) {
                     return;
                 }
@@ -70,7 +70,7 @@ public class MembersDataProvider extends AbstractDataProvider {
 
             @Override
             public void onDelete(Long key) {
-                log.info("members data provider -> on delete");
+                log.debug("members data provider -> on delete");
                 if (membersMap == null) {
                     return;
                 }

--- a/src/main/java/com.elertan/panel/screens/main/UnlockedItemsScreenViewModel.java
+++ b/src/main/java/com.elertan/panel/screens/main/UnlockedItemsScreenViewModel.java
@@ -66,7 +66,7 @@ public class UnlockedItemsScreenViewModel extends BaseViewModel {
 
     private void sortedByListener(PropertyChangeEvent event) {
         SortedBy sortedByValue = (SortedBy) event.getNewValue();
-        log.info("sorted by changed to: {}", sortedByValue);
+        log.debug("sorted by changed to: {}", sortedByValue);
     }
 
     public enum Screen {

--- a/src/main/java/com.elertan/policies/GroundItemsPolicy.java
+++ b/src/main/java/com.elertan/policies/GroundItemsPolicy.java
@@ -274,7 +274,7 @@ public class GroundItemsPolicy extends PolicyBase implements BUPluginLifecycle {
                     for (GroundItemOwnedByData data : entries.values()) {
                         String droppedByPlayerName = data.getDroppedByPlayerName();
                         if (droppedByPlayerName != null) {
-                            log.info(
+                            log.debug(
                                 "Performing player versus player loot check for item '{}' dropped by {}",
                                 itemId,
                                 droppedByPlayerName
@@ -286,11 +286,11 @@ public class GroundItemsPolicy extends PolicyBase implements BUPluginLifecycle {
                             } catch (Exception ignored) {
                             }
                             if (member != null) {
-                                log.info("Player '{}' is part of our group, allow take", droppedByPlayerName);
+                                log.debug("Player '{}' is part of our group, allow take", droppedByPlayerName);
                                 continue;
                             }
 
-                            log.info("Player '{}' is not part of our group, deny take", droppedByPlayerName);
+                            log.debug("Player '{}' is not part of our group, deny take", droppedByPlayerName);
                             buChatService.sendRestrictionMessage(MessageKey.PLAYER_VERSUS_PLAYER_LOOT_RESTRICTION);
                             return;
                         }

--- a/src/main/java/com.elertan/policies/PlayerVersusPlayerPolicy.java
+++ b/src/main/java/com.elertan/policies/PlayerVersusPlayerPolicy.java
@@ -137,30 +137,30 @@ public class PlayerVersusPlayerPolicy extends PolicyBase implements BUPluginLife
         }
 
         String playerName = TextUtils.sanitizePlayerName(player.getName());
-        log.info("loot received for player: {}", playerName);
+        log.debug("loot received for player: {}", playerName);
 
         if (playerDeathLocationsByPlayerName == null) {
-            log.info("playerDeathLocations is null");
+            log.debug("playerDeathLocations is null");
             return;
         }
         ConcurrentLinkedQueue<PlayerDeathLocation> playerDeathLocations = playerDeathLocationsByPlayerName.get(
             playerName);
         if (playerDeathLocations == null) {
-            log.info("playerDeathLocations is null for player: {}", playerName);
+            log.debug("playerDeathLocations is null for player: {}", playerName);
             return;
         }
         if (playerDeathLocations.isEmpty()) {
-            log.info("playerDeathLocations is empty for player: {}", playerName);
+            log.debug("playerDeathLocations is empty for player: {}", playerName);
             return;
         }
         PlayerDeathLocation lastDeathLocation = playerDeathLocations.remove();
         if (lastDeathLocation == null) {
-            log.info("lastDeathLocation is null for player: {}", playerName);
+            log.debug("lastDeathLocation is null for player: {}", playerName);
             return;
         }
 
         if (itemStacks == null) {
-            log.info("item stacks is null, ignoring");
+            log.debug("item stacks is null, ignoring");
             return;
         }
         for (ItemStack itemStack : itemStacks) {
@@ -206,7 +206,7 @@ public class PlayerVersusPlayerPolicy extends PolicyBase implements BUPluginLife
             tickCount
         );
         deathLocations.add(playerDeathLocation);
-        log.info(
+        log.debug(
             "Added death location for player {} at tick count {} for x: {}, y: {}",
             playerName,
             tickCount,

--- a/src/main/java/com.elertan/policies/ShopPolicy.java
+++ b/src/main/java/com.elertan/policies/ShopPolicy.java
@@ -33,6 +33,8 @@ import net.runelite.client.ui.overlay.OverlayPosition;
 public class ShopPolicy extends PolicyBase {
 
     private final ShopmainOverlay shopmainOverlay = new ShopmainOverlay();
+    private volatile boolean shopOpen = false;
+
     @Inject
     private Client client;
     @Inject
@@ -52,6 +54,17 @@ public class ShopPolicy extends PolicyBase {
         GameRulesService gameRulesService, PolicyService policyService,
         WorldTypeService worldTypeService) {
         super(accountConfigurationService, gameRulesService, policyService, worldTypeService);
+    }
+
+    @Override
+    public void startUp() throws Exception {
+        overlayManager.add(shopmainOverlay);
+    }
+
+    @Override
+    public void shutDown() throws Exception {
+        shopOpen = false;
+        overlayManager.remove(shopmainOverlay);
     }
 
     public void onWidgetLoaded(WidgetLoaded event) {
@@ -79,11 +92,11 @@ public class ShopPolicy extends PolicyBase {
     }
 
     private void onShopmainOpened() {
-        overlayManager.add(shopmainOverlay);
+        shopOpen = true;
     }
 
     private void onShopmainClosed() {
-        overlayManager.remove(shopmainOverlay);
+        shopOpen = false;
     }
 
     /**
@@ -101,6 +114,9 @@ public class ShopPolicy extends PolicyBase {
 
         @Override
         public Dimension render(Graphics2D g) {
+            if (!shopOpen) {
+                return null;
+            }
             if (!buPluginConfig.showUnlockedItemsIndicatorInShops()) {
                 return null;
             }

--- a/src/main/java/com.elertan/policies/TradePolicy.java
+++ b/src/main/java/com.elertan/policies/TradePolicy.java
@@ -96,13 +96,13 @@ public class TradePolicy extends PolicyBase {
         String menuTarget = event.getMenuTarget();
         String sanitizedTargetName = TextUtils.sanitizePlayerName(menuTarget);
 
-        log.info("Player is trying to trade with '{}'...", sanitizedTargetName);
+        log.debug("Player is trying to trade with '{}'...", sanitizedTargetName);
         Member member = memberService.getMemberByName(sanitizedTargetName);
         if (member != null) {
-            log.info("...and is a member of our group. All good!");
+            log.debug("...and is a member of our group. All good!");
             return;
         }
-        log.info("...and is not a member of are group.");
+        log.debug("...and is not a member of are group.");
 
         event.consume();
         tradeRestrictionError();

--- a/src/main/java/com.elertan/remote/RemoteStorageService.java
+++ b/src/main/java/com.elertan/remote/RemoteStorageService.java
@@ -179,7 +179,7 @@ public class RemoteStorageService implements BUPluginLifecycle {
             firebaseRealtimeDatabase = null;
         }
 
-        log.info("Dataport has been cleared");
+        log.debug("Dataport has been cleared");
     }
 
     private void configureFromFirebaseRealtimeDatabase(FirebaseRealtimeDatabaseURL url) {

--- a/src/main/java/com.elertan/remote/firebase/FirebaseKeyListStorageAdapterBase.java
+++ b/src/main/java/com.elertan/remote/firebase/FirebaseKeyListStorageAdapterBase.java
@@ -206,7 +206,7 @@ public class FirebaseKeyListStorageAdapterBase<K, V> implements KeyListStoragePo
             K key = stringToKeyTransformer.apply(strKey);
             handleEntryUpdate(key, entryKey, event.getData());
         } else {
-            log.info(
+            log.debug(
                 "FirebaseKeyListStorageAdapterBase ({}): too many path parts, ignoring: {}",
                 basePath,
                 path

--- a/src/main/java/com.elertan/remote/firebase/FirebaseKeyValueStorageAdapterBase.java
+++ b/src/main/java/com.elertan/remote/firebase/FirebaseKeyValueStorageAdapterBase.java
@@ -185,7 +185,7 @@ public class FirebaseKeyValueStorageAdapterBase<K, V> implements KeyValueStorage
                 notifyListenersOnUpdate(key, value);
             }
         } else {
-            log.info(
+            log.debug(
                 "RepositoryFirebaseStorageAdapterbase ({}): too many path parts for unlocked items sse event, will ignored: {}",
                 basePath,
                 path

--- a/src/main/java/com.elertan/remote/firebase/FirebaseObjectListStorageAdapterBase.java
+++ b/src/main/java/com.elertan/remote/firebase/FirebaseObjectListStorageAdapterBase.java
@@ -132,7 +132,7 @@ public class FirebaseObjectListStorageAdapterBase<V> implements ObjectListStorag
             String entryKey = pathParts[1];
             handleEntryUpdate(entryKey, event.getData());
         } else {
-            log.info(
+            log.debug(
                 "FirebaseObjectListStorageAdapterBase ({}): too many path parts, ignoring: {}",
                 basePath,
                 path

--- a/src/main/java/com.elertan/remote/firebase/FirebaseSSEStream.java
+++ b/src/main/java/com.elertan/remote/firebase/FirebaseSSEStream.java
@@ -16,6 +16,7 @@ import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Call;
+import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -54,6 +55,7 @@ public class FirebaseSSEStream {
         this.gson = gson;
         this.databaseURL = databaseURL;
         this.sseClient = httpClient.newBuilder()
+            .connectionPool(new ConnectionPool())
             .retryOnConnectionFailure(true)
             // Keep the TCP/TLS connection alive and detect dead HTTP/2 sockets after sleep
             .pingInterval(Duration.ofSeconds(30))


### PR DESCRIPTION
1. Downgrade non-critical log.info calls to log.debug to reduce log noise
2. Give FirebaseSSEStream its own ConnectionPool so evictAll() no longer affects the shared injected client
3. Refactor ShopPolicy to register overlays in startUp/shutDown and gate rendering via a shopOpen state flag
