### PR TITLE
fix(plugin-hub): refine plugin description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Bronzeman Unleashed Banner](assets/banner.png)
 
-**Ironman without the chores. Flexible rule sets for solo play or shared group progression.**
+**Ironman without the chores. Flexible rule sets for solo and group play. Works with existing or fresh accounts.**
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.elertan'
-version = '0.0.1'
+version = '0.1.0'
 
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation'

--- a/claude-docs/workflows/run-plugin.md
+++ b/claude-docs/workflows/run-plugin.md
@@ -12,7 +12,7 @@
 ./gradlew build
 ```
 
-Output: `build/libs/bronzeman-unleashed-0.0.1.jar`
+Output: `build/libs/bronzeman-unleashed-0.1.0.jar`
 
 ## Run with RuneLite
 

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Bronzeman Unleashed
 author=Elertan
 support=
-description=Ironman without the chores. Flexible rule sets for solo play or shared group progression.
+description=Ironman without the chores. Flexible rule sets for solo and group play. Works with existing or fresh accounts.
 tags=gamemode,trade,restrict,group,bronzeman
 plugins=com.elertan.BUPlugin


### PR DESCRIPTION
## Summary
- update the Plugin Hub description in runelite-plugin.properties
- align the README intro with the final Plugin Hub wording
- keep the previously added Plugin Hub icon unchanged

## Verification
- verified the exact same description string is present in runelite-plugin.properties and README.md
- verified this branch is based on the current origin/dev, which already contains the icon change from PR #111