### PR TITLE
Disable party auto-join and password editing

### DIFF
--- a/src/main/java/com.elertan/BUPartyService.java
+++ b/src/main/java/com.elertan/BUPartyService.java
@@ -33,59 +33,61 @@ public class BUPartyService implements BUPluginLifecycle {
     public void onGameStateChanged(GameStateChanged event) {
         GameState gameState = event.getGameState();
         if (gameState == GameState.LOGGING_IN) {
-            log.debug("Player logging in...");
-
-            if (isWaitingUntilGameRulesReady) {
-                log.debug("Already waiting for game rules to be ready, not waiting again");
-                return;
-            }
-
-            isWaitingUntilGameRulesReady = true;
-            gameRulesService.waitUntilGameRulesReady(null)
-                .whenComplete((__, throwable) -> {
-                    isWaitingUntilGameRulesReady = false;
-
-                    if (throwable != null) {
-                        log.error("error waiting for game rules to be ready", throwable);
-                        return;
-                    }
-
-                    log.debug(
-                        "Waited after login for game rules to be ready, attempting to join party if configured");
-
-                    GameRules gameRules = gameRulesService.getGameRules().get();
-                    String partyPassword = gameRules.getPartyPassword();
-                    if (partyPassword == null || partyPassword.isEmpty()) {
-                        log.debug("No party password set, not attempting to join party");
-                        return;
-                    }
-                    String trimmedPartyPassword = partyPassword.trim();
-                    if (trimmedPartyPassword.isEmpty()) {
-                        log.debug("Party password is empty, not attempting to join party");
-                        return;
-                    }
-
-                    if (!buPluginConfig.shouldAutomaticallyJoinPartyOnLogin()) {
-                        log.debug(
-                            "Plugin is not configured to automatically join the party on login");
-
-                        ChatMessageBuilder builder = new ChatMessageBuilder();
-                        builder.append(
-                            "The bronzeman game rules configuration has a password set, but the plugin is configured to not automatically join the party on login.");
-                        buChatService.sendMessage(builder.build());
-                        return;
-                    }
-
-                    log.debug("Attempting to join party with password {}", trimmedPartyPassword);
-                    partyService.changeParty(trimmedPartyPassword);
-
-                    ChatMessageBuilder builder = new ChatMessageBuilder();
-                    builder.append(
-                        "Automatically joined party using bronzeman game rules configuration.");
-                    buChatService.sendMessage(builder.build());
-
-                    log.debug("Joined party with password {}", trimmedPartyPassword);
-                });
+            // Auto-join on login is disabled for now. Keep the previous flow commented so the
+            // same join logic can be reused when a dedicated manual join action is added.
+//            log.debug("Player logging in...");
+//
+//            if (isWaitingUntilGameRulesReady) {
+//                log.debug("Already waiting for game rules to be ready, not waiting again");
+//                return;
+//            }
+//
+//            isWaitingUntilGameRulesReady = true;
+//            gameRulesService.waitUntilGameRulesReady(null)
+//                .whenComplete((__, throwable) -> {
+//                    isWaitingUntilGameRulesReady = false;
+//
+//                    if (throwable != null) {
+//                        log.error("error waiting for game rules to be ready", throwable);
+//                        return;
+//                    }
+//
+//                    log.debug(
+//                        "Waited after login for game rules to be ready, attempting to join party if configured");
+//
+//                    GameRules gameRules = gameRulesService.getGameRules().get();
+//                    String partyPassword = gameRules.getPartyPassword();
+//                    if (partyPassword == null || partyPassword.isEmpty()) {
+//                        log.debug("No party password set, not attempting to join party");
+//                        return;
+//                    }
+//                    String trimmedPartyPassword = partyPassword.trim();
+//                    if (trimmedPartyPassword.isEmpty()) {
+//                        log.debug("Party password is empty, not attempting to join party");
+//                        return;
+//                    }
+//
+//                    if (!buPluginConfig.shouldAutomaticallyJoinPartyOnLogin()) {
+//                        log.debug(
+//                            "Plugin is not configured to automatically join the party on login");
+//
+//                        ChatMessageBuilder builder = new ChatMessageBuilder();
+//                        builder.append(
+//                            "The bronzeman game rules configuration has a password set, but the plugin is configured to not automatically join the party on login.");
+//                        buChatService.sendMessage(builder.build());
+//                        return;
+//                    }
+//
+//                    log.debug("Attempting to join party with password {}", trimmedPartyPassword);
+//                    partyService.changeParty(trimmedPartyPassword);
+//
+//                    ChatMessageBuilder builder = new ChatMessageBuilder();
+//                    builder.append(
+//                        "Automatically joined party using bronzeman game rules configuration.");
+//                    buChatService.sendMessage(builder.build());
+//
+//                    log.debug("Joined party with password {}", trimmedPartyPassword);
+//                });
         }
     }
 }

--- a/src/main/java/com.elertan/BUPluginConfig.java
+++ b/src/main/java/com.elertan/BUPluginConfig.java
@@ -25,7 +25,6 @@ public interface BUPluginConfig extends Config {
     String minigameSection = "minigameSection";
     @ConfigSection(name = "Debug", description = "Debug settings for testing", position = 99)
     String debugSection = "debugSection";
-    String SHOULD_AUTOMATICALLY_JOIN_PARTY_KEY = "shouldAutomaticallyJoinParty";
     String SHOULD_CHANGE_TO_PARTY_EVEN_IF_ALREADY_IN_PARTY = "shouldChangeToPartyEvenIfAlreadyInParty";
     String ACCOUNT_CONFIG_MAP_JSON_KEY = "accountConfigMapJson";
     String AUTO_OPEN_ACCOUNT_CONFIGURATION_DISABLED_FOR_ACCOUNT_HASHES_JSON_KEY = "autoOpenAccountConfigurationDisabledForAccountHashesJson";
@@ -136,11 +135,6 @@ public interface BUPluginConfig extends Config {
 
     @ConfigItem(keyName = "useItemIconsInChat", name = "Use item icons", description = "Whether to prepend item icons before the item name in the chat", section = chatSection)
     default boolean useItemIconsInChat() {
-        return true;
-    }
-
-    @ConfigItem(keyName = SHOULD_AUTOMATICALLY_JOIN_PARTY_KEY, name = "Auto-join party on login", description = "Whether to automatically join the party when you login on a Bronzeman character (when a party password is set)", section = partySection)
-    default boolean shouldAutomaticallyJoinPartyOnLogin() {
         return true;
     }
 

--- a/src/main/java/com.elertan/panel/components/GameRulesEditor.java
+++ b/src/main/java/com.elertan/panel/components/GameRulesEditor.java
@@ -522,15 +522,13 @@ public class GameRulesEditor extends JPanel {
         gbc.insets = new Insets(0, 0, 5, 0);
 
         JPasswordField partyPasswordTextField = new JPasswordField();
+        partyPasswordTextField.setEditable(false);
+        partyPasswordTextField.setEnabled(false);
         Bindings.bindTextFieldText(partyPasswordTextField, viewModel.partyPasswordProperty);
-        Bindings.bindEnabled(
-            partyPasswordTextField,
-            viewModel.isViewOnlyModeProperty.derive(isViewOnlyMode -> !isViewOnlyMode)
-        );
         panel.add(
             createTextFieldInput(
                 "Party password",
-                "When auto-join is enabled in the plugin configuration, use this password to join the group's party",
+                "Reserved for a future party-join action. This value is currently read-only.",
                 partyPasswordTextField
             ), gbc
         );

--- a/src/main/java/com.elertan/panel/components/GameRulesEditorViewModel.java
+++ b/src/main/java/com.elertan/panel/components/GameRulesEditorViewModel.java
@@ -87,8 +87,6 @@ public class GameRulesEditorViewModel extends BaseViewModel {
         addListener(restrictFaladorPartyRoomBalloonsProperty, updateListener);
         addListener(shareAchievementNotificationsProperty, updateListener);
         addListener(valuableLootNotificationThresholdProperty, updateListener);
-        addListener(partyPasswordProperty, updateListener);
-
         if (setGameRules) {
             initialProps.onGameRulesChanged.accept(gameRules);
         }
@@ -120,12 +118,11 @@ public class GameRulesEditorViewModel extends BaseViewModel {
     }
 
     private boolean isValid() {
-        String partyPassword = partyPasswordProperty.get();
         Integer valuableLootNotificationThreshold = valuableLootNotificationThresholdProperty.get();
         if (valuableLootNotificationThreshold != null && valuableLootNotificationThreshold < 0) {
             return false;
         }
-        return partyPassword == null || partyPassword.length() <= 20;
+        return true;
     }
 
     private void tryUpdateGameRules() {
@@ -133,6 +130,9 @@ public class GameRulesEditorViewModel extends BaseViewModel {
             props.onGameRulesChanged.accept(null);
             return;
         }
+
+        GameRules currentGameRules = props.getGameRules();
+        String partyPassword = currentGameRules == null ? null : currentGameRules.getPartyPassword();
 
         GameRules newGameRules = GameRules.builder()
             .lastUpdatedByAccountHash(props.getAccountHash())
@@ -147,7 +147,7 @@ public class GameRulesEditorViewModel extends BaseViewModel {
             .restrictFaladorPartyRoomBalloons(restrictFaladorPartyRoomBalloonsProperty.get())
             .shareAchievementNotifications(shareAchievementNotificationsProperty.get())
             .valuableLootNotificationThreshold(valuableLootNotificationThresholdProperty.get())
-            .partyPassword(partyPasswordProperty.get())
+            .partyPassword(partyPassword)
             .build();
         props.onGameRulesChanged.accept(newGameRules);
     }


### PR DESCRIPTION
## Summary
- make the game rules party password field read-only and preserve its stored value on rule updates
- remove the plugin config toggle for auto-joining the party on login
- comment out the current login-based join flow so it can be reused later for a manual join action

## Testing
- ./gradlew compileJava