### PR TITLE
Fix local progress failure replay on startup

### DIFF
--- a/src/main/java/com.elertan/BUPanelService.java
+++ b/src/main/java/com.elertan/BUPanelService.java
@@ -50,7 +50,11 @@ public class BUPanelService implements BUPluginLifecycle {
         accountConfigSubscription = accountConfigurationService.currentAccountConfiguration()
             .subscribe(this::currentAccountConfigurationChangeListener);
         localProgressOpenFailureSubscription = storageService.getLocalProgressOpenFailure()
-            .subscribe(this::onLocalProgressOpenFailure);
+            .subscribeImmediate((failure, __) -> {
+                if (failure != null) {
+                    onLocalProgressOpenFailure(failure);
+                }
+            });
     }
 
     @Override
@@ -93,6 +97,7 @@ public class BUPanelService implements BUPluginLifecycle {
     private void onLocalProgressOpenFailure(StorageService.LocalProgressOpenFailure failure) {
         // Drop back to setup before showing the error so the panel is not left bound to an
         // unusable local session.
+        log.error("Could not open local progress", failure.getCause());
         accountConfigurationService.setCurrentAccountConfiguration(null);
         SwingUtilities.invokeLater(() -> JOptionPane.showMessageDialog(
             null,

--- a/src/main/java/com.elertan/remote/StorageService.java
+++ b/src/main/java/com.elertan/remote/StorageService.java
@@ -139,6 +139,9 @@ public class StorageService implements BUPluginLifecycle {
         // Opening a storage session can now finish asynchronously. Track which open attempt is the
         // latest so an older callback cannot overwrite a newer account configuration.
         int generation = sessionGeneration.incrementAndGet();
+        // Clear any previously reported local-progress open failure before we process the current
+        // account configuration so late subscribers only replay failures that still apply.
+        localProgressOpenFailure.set(null);
         try {
             clearCurrentSession();
         } catch (Exception e) {

--- a/src/main/java/com.elertan/remote/local/LocalStorageAdapters.java
+++ b/src/main/java/com.elertan/remote/local/LocalStorageAdapters.java
@@ -4,7 +4,6 @@ import com.elertan.remote.KeyListStoragePort;
 import com.elertan.remote.KeyValueStoragePort;
 import com.elertan.remote.ObjectStoragePort;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import java.io.IOException;
 import java.io.Reader;
@@ -31,7 +30,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class LocalStorageAdapters {
 
-    private static final Gson PRETTY_GSON = new GsonBuilder().setPrettyPrinting().create();
     private static final AtomicInteger EXECUTOR_COUNTER = new AtomicInteger();
 
     private LocalStorageAdapters() {
@@ -180,9 +178,7 @@ public final class LocalStorageAdapters {
             for (Map.Entry<K, V> entry : cache.entrySet()) {
                 raw.put(keyToString.apply(entry.getKey()), entry.getValue());
             }
-            // Use the adapter gson for type-aware serialization, then pretty-print the resulting
-            // JSON tree so the on-disk files stay stable and readable.
-            writeJsonFile(filePath, PRETTY_GSON.toJson(gson.toJsonTree(raw)));
+            writeJsonFile(filePath, gson.toJson(raw));
         }
     }
 
@@ -279,9 +275,7 @@ public final class LocalStorageAdapters {
                 deleteFile(filePath);
                 return;
             }
-            // Use the adapter gson for type-aware serialization, then pretty-print the resulting
-            // JSON tree so the on-disk files stay stable and readable.
-            writeJsonFile(filePath, PRETTY_GSON.toJson(gson.toJsonTree(cache)));
+            writeJsonFile(filePath, gson.toJson(cache));
         }
     }
 


### PR DESCRIPTION
This fixes two follow-up issues in the local storage flow.

- replay local-progress open failures correctly for late subscribers during startup
- stop creating a separate local Gson instance in `LocalStorageAdapters` and use the injected Gson path instead

Validation:
- `./gradlew compileJava`