### PR TITLE
fix(overlay): preserve under-widgets layer

### DIFF
--- a/src/main/java/com.elertan/overlays/ItemUnlockOverlay.java
+++ b/src/main/java/com.elertan/overlays/ItemUnlockOverlay.java
@@ -234,11 +234,11 @@ public class ItemUnlockOverlay extends Overlay {
         }
 
         Point overlayLocation = getViewportOverlayLocation();
-        setPreferredLocation(overlayLocation);
-
         Point currentLocation = getBounds().getLocation();
         int originX = overlayLocation.x - currentLocation.x;
         int originY = overlayLocation.y - currentLocation.y;
+        // Preferred locations cause RuneLite to promote UNDER_WIDGETS overlays to ABOVE_WIDGETS.
+        getBounds().setLocation(overlayLocation);
         int y = originY;
         int frameX = originX + (WIDTH - visibleWidth) / 2;
 


### PR DESCRIPTION
## Summary

- Keep the item-unlock overlay in RuneLite's `UNDER_WIDGETS` layer.
- Position the overlay through its bounds instead of setting a preferred location, which causes RuneLite to promote it to `ABOVE_WIDGETS`.

## Testing

- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home ./gradlew test`