### PR TITLE
Merge dev into main

### DIFF
--- a/src/main/java/com.elertan/overlays/ItemUnlockOverlay.java
+++ b/src/main/java/com.elertan/overlays/ItemUnlockOverlay.java
@@ -234,11 +234,11 @@ public class ItemUnlockOverlay extends Overlay {
         }
 
         Point overlayLocation = getViewportOverlayLocation();
-        setPreferredLocation(overlayLocation);
-
         Point currentLocation = getBounds().getLocation();
         int originX = overlayLocation.x - currentLocation.x;
         int originY = overlayLocation.y - currentLocation.y;
+        // Preferred locations cause RuneLite to promote UNDER_WIDGETS overlays to ABOVE_WIDGETS.
+        getBounds().setLocation(overlayLocation);
         int y = originY;
         int frameX = originX + (WIDTH - visibleWidth) / 2;
 


### PR DESCRIPTION
This PR merges the current `dev` branch into `main`.

The delta is the overlay-layer fix from #144:
- preserve the item-unlock overlay's `UNDER_WIDGETS` layer
- position it through its bounds instead of a preferred location, avoiding RuneLite promotion to `ABOVE_WIDGETS`

Validation:
- confirmed the `origin/main...origin/dev` diff contains only `ItemUnlockOverlay.java`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home ./gradlew test` passed for the underlying fix