### PR TITLE
Bump dev version to 0.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.elertan'
-version = '0.2.0'
+version = '0.2.1'
 
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation'

--- a/claude-docs/workflows/run-plugin.md
+++ b/claude-docs/workflows/run-plugin.md
@@ -12,7 +12,7 @@
 ./gradlew build
 ```
 
-Output: `build/libs/bronzeman-unleashed-0.2.0.jar`
+Output: `build/libs/bronzeman-unleashed-0.2.1.jar`
 
 ## Run with RuneLite
 


### PR DESCRIPTION
This bumps the plugin version on `dev` from `0.2.0` to `0.2.1`.

It also updates the `run-plugin` workflow example so the documented jar name matches the build output.

Verification:
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home ./gradlew build`
- confirmed `build/libs/bronzeman-unleashed-0.2.1.jar` was produced