### PR TITLE
Merge dev into main

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.elertan'
-version = '0.2.0'
+version = '0.2.1'
 
 tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation'

--- a/claude-docs/workflows/run-plugin.md
+++ b/claude-docs/workflows/run-plugin.md
@@ -12,7 +12,7 @@
 ./gradlew build
 ```
 
-Output: `build/libs/bronzeman-unleashed-0.2.0.jar`
+Output: `build/libs/bronzeman-unleashed-0.2.1.jar`
 
 ## Run with RuneLite
 


### PR DESCRIPTION
This PR merges the current `dev` branch into `main`.

The delta is the version bump from #146:
- bump the Gradle project version from `0.2.0` to `0.2.1`
- update the documented build artifact name to `bronzeman-unleashed-0.2.1.jar`

Validation:
- confirmed the `origin/main...origin/dev` diff contains only `build.gradle` and `claude-docs/workflows/run-plugin.md`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home ./gradlew build` passed
- confirmed `build/libs/bronzeman-unleashed-0.2.1.jar` was produced