### PR TITLE
fix(metadata): add Plugin Hub build mode

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Bronzeman Unleashed
 author=Elertan
-support=
+build=standard
 description=Ironman without the chores. Flexible rule sets for solo and group play. Works with existing or fresh accounts.
 tags=gamemode,trade,restrict,group,bronzeman
 plugins=com.elertan.BUPlugin


### PR DESCRIPTION
This fixes the Plugin Hub packager metadata for version `0.2.1`.

Changes:
- declare `build=standard` in `runelite-plugin.properties`
- remove the empty `support=` property that generated a warning

Validation:
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home ./gradlew test` passed
- confirmed the metadata contains exactly one `build=standard` entry and no `support=` entry