### PR TITLE
Merge dev into main

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,6 @@
 displayName=Bronzeman Unleashed
 author=Elertan
-support=
+build=standard
 description=Ironman without the chores. Flexible rule sets for solo and group play. Works with existing or fresh accounts.
 tags=gamemode,trade,restrict,group,bronzeman
 plugins=com.elertan.BUPlugin


### PR DESCRIPTION
This PR merges the current `dev` branch into `main`.

The delta is the Plugin Hub metadata fix from #148:
- declare `build=standard` in `runelite-plugin.properties`
- remove the empty `support=` property that generated a warning

Validation:
- confirmed the `origin/main...origin/dev` diff contains only `runelite-plugin.properties`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home ./gradlew test` passed
- confirmed version `0.2.1` remains unchanged